### PR TITLE
Added version of eofnewline for lite-xl

### DIFF
--- a/plugins/eofnewline-xl.lua
+++ b/plugins/eofnewline-xl.lua
@@ -1,0 +1,30 @@
+-- lite-xl 1.16
+local core = require "core"
+local command = require "core.command"
+local Doc = require "core.doc"
+
+local function eof_newline(doc)
+    local leof,neof = #doc.lines,#doc.lines
+    for i = leof,1,-1 do
+        if not string.match(doc.lines[i],"^%s*$") then break end
+        neof = i
+    end
+    local eol,_ = string.find(doc.lines[neof],"\n")
+    if eol then
+        doc:remove(neof,eol,math.huge,math.huge)
+        return
+    end
+    doc:insert(neof,math.huge,"\n")
+end
+
+command.add("core.docview", {
+    ["eof-newline:eof-newline"] = function()
+        eof_newline(core.active_view.doc)
+    end,
+})
+
+local save = Doc.save
+    Doc.save = function(self, ...)
+    eof_newline(self)
+    save(self, ...)
+end


### PR DESCRIPTION
Duplicated eofnewline.lua and added `-- lite-xl 1.16`.
This is required for it to work in [lite-xl](https://github.com/franko/lite-xl).